### PR TITLE
remove dv

### DIFF
--- a/src/design.jl
+++ b/src/design.jl
@@ -81,6 +81,8 @@ julia> generate(d)
 """
 function generate(expdesign::MultiSubjectDesign)
 	#generate(expdesign::AbstractDesign) = generate(MersenneTwister(1),expdesign)
+
+	@assert :dv ∉ keys(merge(expdesign.subjects_between,expdesign.items_betwee,expdesign.both_within)) "due to technical limitations in MixedModelsSim.jl, `:dv` cannot be used as a factorname"
 	data = DataFrame(
 		MixedModelsSim.simdat_crossed(
 			expdesign.n_subjects, 
@@ -91,7 +93,7 @@ function generate(expdesign::MultiSubjectDesign)
 		)
 	)
 	rename!(data,:subj => :subject)
-	
+	select!(data,Not(:dv)) # remove the default column from MixedModelsSim.jl - we don't need it in UnfoldSim.jl
 	# by default does nothing
 	data = expdesign.tableModifyFun(data)
 	

--- a/src/design.jl
+++ b/src/design.jl
@@ -81,8 +81,12 @@ julia> generate(d)
 """
 function generate(expdesign::MultiSubjectDesign)
 	#generate(expdesign::AbstractDesign) = generate(MersenneTwister(1),expdesign)
+	
+	# check that :dv is not in any condition
+	allconditions = [expdesign.subjects_between,expdesign.items_between,expdesign.both_within]
+	@assert :dv ∉ keys(merge(allconditions[.!isnothing.(allconditions)]...)) "due to technical limitations in MixedModelsSim.jl, `:dv` cannot be used as a factorname"
 
-	@assert :dv ∉ keys(merge(expdesign.subjects_between,expdesign.items_betwee,expdesign.both_within)) "due to technical limitations in MixedModelsSim.jl, `:dv` cannot be used as a factorname"
+	
 	data = DataFrame(
 		MixedModelsSim.simdat_crossed(
 			expdesign.n_subjects, 

--- a/test/design.jl
+++ b/test/design.jl
@@ -18,15 +18,15 @@
                                 n_items = 100,both_within= Dict(:A=>nlevels(5),:B=>nlevels(2)))
         
         
-        @test size(generate(des)) == (10*100*5*2,5)
-        @test names(generate(des)) == ["subject","item","A","B","dv"]
+        @test size(generate(des)) == (10*100*5*2,4)
+        @test names(generate(des)) == ["subject","item","A","B"]
         @test sum(generate(des).A .== "S2") == 10*100*2
         @test sum(generate(des).B .== "S2") == 10*100*5
 
         # check that finally everything is sorted by subject
         des = MultiSubjectDesign(;n_subjects=10,
                                 n_items = 100,both_within= Dict(:A=>nlevels(5),:B=>nlevels(2)),
-                                tableModifyFun = x->sort(x,order(:dv,rev=true)))
+                                tableModifyFun = x->sort(x,order(:item,rev=true)))
         @test generate(des).subject[1] == "S01"
              
         # check tableModifyFun
@@ -35,6 +35,10 @@
         tableModifyFun = x->sort(x,order(:B,rev=true)))
         @test generate(des).B[1] == "S2"
 
+        # check that this throws an error because of `dv` as condition name
+        des = MultiSubjectDesign(;n_subjects=10,
+            n_items = 100,both_within= Dict(:dv=>nlevels(5),:B=>nlevels(2)))
+        @test_throws AssertionError generate(des)
     end
 
     @testset "RepeatDesign" begin
@@ -47,7 +51,7 @@
         );
 
         design = RepeatDesign(designOnce,3); 
-        @test size(generate(design)) == (8*12*3,4)
+        @test size(generate(design)) == (8*12*3,3)
         @test size(design) == (8*3,12)
         #--- single sub
 

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -17,7 +17,7 @@ end
 
 function gen_debug_component()
     basisfunction = [zeros(10) ones(10) zeros(10)]
-    formula = @formula(dv ~ 1 + stimType + (1 + stimType | subj))
+    formula = @formula(0 ~ 1 + stimType + (1 + stimType | subj))
     contrasts = Dict(:stimType => DummyCoding())
     β = [2.0, 0.5]
     σ_ranef = Dict(:subj => [1, 0.0])


### PR DESCRIPTION
finally removed the requirement to write dv~1+cond+(1|sub) instead of 0~
also removed the `dv` column from generate(MultiSubjectDesign)

non-breaking

- remove annoying column :dv
- fix tests after dv removal
