### PR TITLE
Add noise artifact

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,7 +1,1 @@
-[RealNoise]
-git-tree-sha1 = "6c460cf2eccecd24499618112adbbe7e403fa1ee"
-lazy = true
 
-    [[RealNoise.download]]
-    sha256 = "12a1f72f5e5ee73ff347951e1459cdbad106193da7933cc153003d53b90c5d6a"
-    url = "https://github.com/cormullion/juliamono/releases/download/v0.030/JuliaMono.tar.gz"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,0 +1,7 @@
+[RealNoise]
+git-tree-sha1 = "6c460cf2eccecd24499618112adbbe7e403fa1ee"
+lazy = true
+
+    [[RealNoise.download]]
+    sha256 = "12a1f72f5e5ee73ff347951e1459cdbad106193da7933cc153003d53b90c5d6a"
+    url = "https://github.com/cormullion/juliamono/releases/download/v0.030/JuliaMono.tar.gz"

--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,11 @@
 name = "UnfoldSim"
 uuid = "ed8ae6d2-84d3-44c6-ab46-0baf21700804"
-authors = ["Benedikt Ehinger","Luis Lips", "Judith Schepers","Maanik Marathe"]
+authors = ["Benedikt Ehinger", "Luis Lips", "Judith Schepers", "Maanik Marathe"]
 version = "0.1.6"
 
 [deps]
+ArtifactUtils = "8b73e784-e7d8-4ea5-973d-377fed4e3bce"
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/dev/add_artifact_to_toml.jl
+++ b/src/dev/add_artifact_to_toml.jl
@@ -1,0 +1,34 @@
+using Pkg.Artifacts, ArtifactsUtils
+
+# Get path to the Artifact.toml
+artifacts_toml = joinpath(@__DIR__, "Artifacts.toml")
+
+# Check if noise artefact exists in Artefact.toml and get hash
+noise_hash = artifact_hash("RealNoise", artifacts_toml)
+
+# Check if has does not exist (i.e. Artifact not added) or if artifact doesn't exist on disk;
+# create/ add to .toml if fullfilled
+if isnothing(noise_hash) || !artifact_exists(noise_hash)
+    add_artifact!(
+                     "Artifacts.toml",
+                     "RealNoise",
+                     "https://github.com/cormullion/juliamono/releases/download/v0.030/JuliaMono.tar.gz", # Change this line to actual dataset
+                     force=true,
+                     lazy=true, # If lazy is set to true, even if download information is available, this artifact will not be downloaded until it is accessed via the artifact"name" syntax, or ensure_artifact_installed() is called upon it.
+                    )
+end
+
+#=
+For the specific use case of using artifacts that were previously bound, 
+we have the shorthand notation artifact"name" which will automatically 
+search for the Artifacts.toml file contained within the current package, look up the given artifact by name,
+install it if it is not yet installed, then return the path to that given artifact.
+=#
+
+
+# The following can be used to install the artifact/ ensure it is installed
+#import Pkg; Pkg.ensure_artifact_installed("RealNoise", "Artifacts.toml")
+
+# The below can be used to get the path to the artifact file
+# According to docs this should also install the Artifact if it is not already installed
+# artifact"RealNoise"


### PR DESCRIPTION
I wrote a short script in a dev subfolder that should be able to easily add an artifact to the package. For now the artifact is lazily loaded, i.e. the artifact is not installed/ downloaded unless it is called upon.
We would only need to change the url in the script, once we have uploaded a noise dataset as .tar file.

Real noise can then be used by calling on the artifact by using `artifact"RealNoise"` to get the artifact path and then loading it.  