### PR TITLE
include lower truncation for normal distrubution

### DIFF
--- a/src/onset.jl
+++ b/src/onset.jl
@@ -11,6 +11,7 @@ end
     σ  # variance
     offset = 0 # additional offset
     truncate_upper = nothing # truncate at some sample?
+    truncate_lower = nothing # truncate at some lower sample?
 end
 
 #-------------
@@ -23,6 +24,9 @@ function rand_onsets(rng,onset::LogNormalOnset,design::AbstractDesign)
     fun = LogNormal(onset.μ,onset.σ)
     if !isnothing(onset.truncate_upper)
         fun = truncated(fun;upper=onset.truncate_upper)
+    end
+    if !isnothing(onset.truncate_lower)
+        fun = truncated(fun;lower=onset.truncate_lower)
     end
     return Int.(round.(onset.offset .+ rand(deepcopy(rng), fun, s)))
 end


### PR DESCRIPTION
Lower truncation might be useful to simulate specific experiments where there was/ is an exclusion criterion, artificially changing the distribution.

E.g. in our Oddball experiment, we set a lower RT threshold, throwing out every trial below.