### PR TITLE
Modified "simulateERP" tutorial: Added splines and fixed overlapping legend and colorbar

### DIFF
--- a/docs/literate/tutorials/simulateERP.jl
+++ b/docs/literate/tutorials/simulateERP.jl
@@ -36,27 +36,27 @@ p3 =  LinearModelComponent(;
 
 # Now we can simply combine the components and simulate 
 components = [p1, n1, p3] 
-data,evts = simulate(
-        MersenneTwister(1),
-        design,
-        components,
-        UniformOnset(;width=0,offset=1000),
-        PinkNoise(),
+data, evts = simulate(
+    MersenneTwister(1),
+    design,
+    components,
+    UniformOnset(;width=0,offset=1000),
+    PinkNoise(),
 );
 
 
 # ## Analysis
 # Let's check that everything worked out well, by using Unfold
 m = fit(
-        UnfoldModel,
-        Dict(
-                Any => (
-                        @formula(0 ~ 1 + condition + spl(continuous, 4)),
-                        firbasis(τ = [-0.1, 1], sfreq = 100, name = "basis"),
-                ),
+    UnfoldModel,
+    Dict(
+        Any => (
+            @formula(0 ~ 1 + condition + spl(continuous, 4)),
+            firbasis(τ = [-0.1, 1], sfreq = 100, name = "basis"),
         ),
-        evts,
-        data,
+    ),
+    evts,
+    data,
 );
 
 # first the "pure" beta/linear regression parameters

--- a/docs/literate/tutorials/simulateERP.jl
+++ b/docs/literate/tutorials/simulateERP.jl
@@ -41,7 +41,17 @@ data,evts = simulate(MersenneTwister(1),design,components,UniformOnset(;width=0,
 
 # ## Analysis
 # Let's check that everything worked out well, by using Unfold
-m = fit(UnfoldModel, Dict(Any=>(@formula(0~1+condition+spl(continuous,4)),firbasis(τ=[-0.1,1],sfreq=100,name="basis"))),evts,data);
+m = fit(
+    UnfoldModel,
+    Dict(
+        Any => (
+            @formula(0 ~ 1 + condition + spl(continuous, 4)),
+            firbasis(τ = [-0.1, 1], sfreq = 100, name = "basis"),
+        ),
+    ),
+    evts,
+    data,
+);
 
 # first the "pure" beta/linear regression parameters
 plot_erp(coeftable(m))

--- a/docs/literate/tutorials/simulateERP.jl
+++ b/docs/literate/tutorials/simulateERP.jl
@@ -8,31 +8,31 @@ using UnfoldMakie
 
 # Let's grab a SingleSubjectDesign and add a continuous predictor
 design = SingleSubjectDesign(;
-        conditions=Dict(:condition=>["car","face"],:continuous=>range(-5,5,length=10))
-        ) |> x->RepeatDesign(x,100);
+    conditions=Dict(:condition=>["car","face"],:continuous=>range(-5,5,length=10))
+    ) |> x->RepeatDesign(x,100);
 
 # Let's make use of the prespecified basis functions, but use different formulas + parameters for each!
 
 # **p100** is unaffected by our design and has amplitude of 5
 p1 =  LinearModelComponent(;
-        basis = p100(),
-        formula = @formula(0~1),
-        β = [5]
-        );
+    basis = p100(),
+    formula = @formula(0~1),
+    β = [5],
+);
 
 # **n170** has a condition effect, faces are more negative than cars
 n1 =  LinearModelComponent(;
-        basis = n170(),
-        formula = @formula(0~1+condition),
-        β = [5,-3]
-        );
+    basis = n170(),
+    formula = @formula(0~1+condition),
+    β = [5,-3],
+);
 # **p300** has a continuous effect, higher continuous values will result in larger P300's
 # include both a linear and a quadratic effect of the continuous variable
 p3 =  LinearModelComponent(;
         basis = p300(),
         formula = @formula(0 ~ 1 + continuous + continuous^2),
-        β = [5,1,0.2]
-        );
+        β = [5,1,0.2],
+);
 
 # Now we can simply combine the components and simulate 
 components = [p1, n1, p3] 
@@ -64,10 +64,10 @@ plot_erp(coeftable(m))
 
 # and now beautifully visualized as marginal betas / predicted ERPs
 f = plot_erp(
-        effects(Dict(:condition => ["car", "face"], :continuous => -5:5), m);
-        mapping = (:color => :continuous, linestyle = :condition, group = :continuous),
-        legend = (; valign = :top, halign = :right, tellwidth = false),
-        categorical_color = false,
+    effects(Dict(:condition => ["car", "face"], :continuous => -5:5), m);
+    mapping = (:color => :continuous, linestyle = :condition, group = :continuous),
+    legend = (; valign = :top, halign = :right, tellwidth = false),
+    categorical_color = false,
 );
 
 # Workaround to separate legend and colorbar (will be fixed in a future UnfoldMakie version)

--- a/docs/literate/tutorials/simulateERP.jl
+++ b/docs/literate/tutorials/simulateERP.jl
@@ -57,10 +57,12 @@ m = fit(
 plot_erp(coeftable(m))
 
 # and now beautifully visualized as marginal betas / predicted ERPs
-f = plot_erp(effects(Dict(:condition => ["car", "face"], :continuous => -5:5), m);
-        mapping=(:color => :continuous, linestyle=:condition, group=:continuous),
-        legend = (; valign=:top, halign=:right, tellwidth = false),
-        categorical_color=false);
+f = plot_erp(
+    effects(Dict(:condition => ["car", "face"], :continuous => -5:5), m);
+    mapping = (:color => :continuous, linestyle = :condition, group = :continuous),
+    legend = (; valign = :top, halign = :right, tellwidth = false),
+    categorical_color = false,
+);
 
 # Workaround to separate legend and colorbar (will be fixed in a future UnfoldMakie version)
 legend = f.content[2]

--- a/docs/literate/tutorials/simulateERP.jl
+++ b/docs/literate/tutorials/simulateERP.jl
@@ -66,5 +66,5 @@ f = plot_erp(
 
 # Workaround to separate legend and colorbar (will be fixed in a future UnfoldMakie version)
 legend = f.content[2]
-f[:,1] = legend
+f[:, 1] = legend
 current_figure()

--- a/docs/literate/tutorials/simulateERP.jl
+++ b/docs/literate/tutorials/simulateERP.jl
@@ -7,40 +7,40 @@ using UnfoldMakie
 # Here we will learn how to simulate a typical ERP complex with P100, N170, P300.
 
 # Let's grab a SingleSubjectDesign and add a continuous predictor
-design = SingleSubjectDesign(;
-    conditions=Dict(:condition=>["car","face"],:continuous=>range(-5,5,length=10))
-    ) |> x->RepeatDesign(x,100);
+design =
+    SingleSubjectDesign(;
+        conditions = Dict(
+            :condition => ["car","face"],
+            :continuous => range(-5,5,length=10),
+        )
+    ) |> x -> RepeatDesign(x,100);
 
 # Let's make use of the prespecified basis functions, but use different formulas + parameters for each!
 
 # **p100** is unaffected by our design and has amplitude of 5
-p1 =  LinearModelComponent(;
-    basis = p100(),
-    formula = @formula(0~1),
-    β = [5],
-);
+p1 = LinearModelComponent(; basis = p100(), formula = @formula(0~1), β = [5]);
 
 # **n170** has a condition effect, faces are more negative than cars
-n1 =  LinearModelComponent(;
+n1 = LinearModelComponent(;
     basis = n170(),
-    formula = @formula(0~1+condition),
-    β = [5,-3],
+    formula = @formula(0 ~ 1 + condition),
+    β = [5, -3],
 );
 # **p300** has a continuous effect, higher continuous values will result in larger P300's
 # include both a linear and a quadratic effect of the continuous variable
 p3 =  LinearModelComponent(;
-        basis = p300(),
-        formula = @formula(0 ~ 1 + continuous + continuous^2),
-        β = [5,1,0.2],
+    basis = p300(),
+    formula = @formula(0 ~ 1 + continuous + continuous^2),
+    β = [5, 1, 0.2],
 );
 
 # Now we can simply combine the components and simulate 
-components = [p1, n1, p3] 
+components = [p1, n1, p3]
 data, evts = simulate(
     MersenneTwister(1),
     design,
     components,
-    UniformOnset(;width=0,offset=1000),
+    UniformOnset(; width = 0,offset = 1000),
     PinkNoise(),
 );
 

--- a/docs/literate/tutorials/simulateERP.jl
+++ b/docs/literate/tutorials/simulateERP.jl
@@ -10,15 +10,15 @@ using UnfoldMakie
 design =
     SingleSubjectDesign(;
         conditions = Dict(
-            :condition => ["car","face"],
-            :continuous => range(-5,5,length=10),
-        )
-    ) |> x -> RepeatDesign(x,100);
+            :condition => ["car", "face"],
+            :continuous => range(-5, 5, length = 10),
+        ),
+    ) |> x -> RepeatDesign(x, 100);
 
 # Let's make use of the prespecified basis functions, but use different formulas + parameters for each!
 
 # **p100** is unaffected by our design and has amplitude of 5
-p1 = LinearModelComponent(; basis = p100(), formula = @formula(0~1), β = [5]);
+p1 = LinearModelComponent(; basis = p100(), formula = @formula(0 ~ 1), β = [5]);
 
 # **n170** has a condition effect, faces are more negative than cars
 n1 = LinearModelComponent(;
@@ -28,7 +28,7 @@ n1 = LinearModelComponent(;
 );
 # **p300** has a continuous effect, higher continuous values will result in larger P300's
 # include both a linear and a quadratic effect of the continuous variable
-p3 =  LinearModelComponent(;
+p3 = LinearModelComponent(;
     basis = p300(),
     formula = @formula(0 ~ 1 + continuous + continuous^2),
     β = [5, 1, 0.2],
@@ -40,7 +40,7 @@ data, evts = simulate(
     MersenneTwister(1),
     design,
     components,
-    UniformOnset(; width = 0,offset = 1000),
+    UniformOnset(; width = 0, offset = 1000),
     PinkNoise(),
 );
 

--- a/docs/literate/tutorials/simulateERP.jl
+++ b/docs/literate/tutorials/simulateERP.jl
@@ -30,27 +30,33 @@ n1 =  LinearModelComponent(;
 # include both a linear and a quadratic effect of the continuous variable
 p3 =  LinearModelComponent(;
         basis = p300(),
-        formula=@formula(0 ~ 1 + continuous + continuous^2),
+        formula = @formula(0 ~ 1 + continuous + continuous^2),
         β = [5,1,0.2]
         );
 
 # Now we can simply combine the components and simulate 
-components = [p1,n1,p3] 
-data,evts = simulate(MersenneTwister(1),design,components,UniformOnset(;width=0,offset=1000),PinkNoise());
+components = [p1, n1, p3] 
+data,evts = simulate(
+        MersenneTwister(1),
+        design,
+        components,
+        UniformOnset(;width=0,offset=1000),
+        PinkNoise(),
+);
 
 
 # ## Analysis
 # Let's check that everything worked out well, by using Unfold
 m = fit(
-    UnfoldModel,
-    Dict(
-        Any => (
-            @formula(0 ~ 1 + condition + spl(continuous, 4)),
-            firbasis(τ = [-0.1, 1], sfreq = 100, name = "basis"),
+        UnfoldModel,
+        Dict(
+                Any => (
+                        @formula(0 ~ 1 + condition + spl(continuous, 4)),
+                        firbasis(τ = [-0.1, 1], sfreq = 100, name = "basis"),
+                ),
         ),
-    ),
-    evts,
-    data,
+        evts,
+        data,
 );
 
 # first the "pure" beta/linear regression parameters
@@ -58,10 +64,10 @@ plot_erp(coeftable(m))
 
 # and now beautifully visualized as marginal betas / predicted ERPs
 f = plot_erp(
-    effects(Dict(:condition => ["car", "face"], :continuous => -5:5), m);
-    mapping = (:color => :continuous, linestyle = :condition, group = :continuous),
-    legend = (; valign = :top, halign = :right, tellwidth = false),
-    categorical_color = false,
+        effects(Dict(:condition => ["car", "face"], :continuous => -5:5), m);
+        mapping = (:color => :continuous, linestyle = :condition, group = :continuous),
+        legend = (; valign = :top, halign = :right, tellwidth = false),
+        categorical_color = false,
 );
 
 # Workaround to separate legend and colorbar (will be fixed in a future UnfoldMakie version)


### PR DESCRIPTION
- I added an quadratic effect of the `continuous` variable
- I added splines in the Unfold model
- I added a workaround to separate the overlapping legend and colorbar