### PR TITLE
FormulaOnsets

### DIFF
--- a/docs/literate/reference/onsettypes.jl
+++ b/docs/literate/reference/onsettypes.jl
@@ -282,3 +282,25 @@ end
 #        - if `offset` < `length(signal.basis)` -> there might be overlap, depending on the other parameters of the onset distribution
 
 # [^1]: Wikipedia contributors. (2023, December 5). Log-normal distribution. In Wikipedia, The Free Encyclopedia. Retrieved 12:27, December 7, 2023, from https://en.wikipedia.org/w/index.php?title=Log-normal_distribution&oldid=1188400077# 
+
+
+
+
+# ## Design-dependent `FormulaXOnset`
+
+# For additional control we provide `FormulaUniformOnset` and `FormulaLogNormalOnset` types, that allow to control all parameters by specifying formulas
+o = UnfoldSim.FormulaUniformOnset(
+    width_formula = @formula(0 ~ 1 + cond),
+    width_β = [50, 20],
+)
+events = generate_events(design)
+onsets = UnfoldSim.simulate_interonset_distances(MersenneTwister(42), o, design)
+
+f = Figure()
+ax = f[1, 1] = Axis(f)
+hist!(ax, onsets[events.cond.=="A"], bins = range(0, 100, step = 1), label = "cond: A")
+hist!(ax, onsets[events.cond.=="B"], bins = range(0, 100, step = 1), label = "cond: B")
+axislegend(ax)
+f
+
+# Voila - the inter-onset intervals are `20` samples longer for condition `B`, exactly as specified.`

--- a/src/component.jl
+++ b/src/component.jl
@@ -145,22 +145,32 @@ julia> simulate_component(StableRNG(1),c,design)
 """
 function simulate_component(rng, c::LinearModelComponent, design::AbstractDesign)
     events = generate_events(design)
+    X = generate_designmatrix(c.formula, events, c.contrasts)
+    y = X * β
 
+    return y' .* c.basis
+end
+
+
+"""
+Helper function to generate a designmatrix from formula, events and contrasts.
+"""
+function generate_designmatrix(formula, events, contrasts)
     # special case, intercept only 
     # https://github.com/JuliaStats/StatsModels.jl/issues/269
-    if c.formula.rhs == ConstantTerm(1)
+    if formula.rhs == ConstantTerm(1)
         X = ones(nrow(events), 1)
     else
-        if isempty(c.contrasts)
-            m = StatsModels.ModelFrame(c.formula, events)
+        if isempty(contrasts)
+            m = StatsModels.ModelFrame(formula, events)
         else
-            m = StatsModels.ModelFrame(c.formula, events; contrasts = c.contrasts)
+            m = StatsModels.ModelFrame(formula, events; contrasts = contrasts)
         end
         X = StatsModels.modelmatrix(m)
     end
-    y = X * c.β
-    return y' .* c.basis
+    return X
 end
+
 """
     simulate_component(rng, c::MixedModelComponent, design::AbstractDesign)
 Generates a MixedModel and simulates data according to c.β and c.σs.


### PR DESCRIPTION
this was fun, even though specificatio is a bit ugly (similar to the components interface issue, one always has to specify formula and betas separately...)

In any case, I was wondering if we should point the implementation of UniformOnset to the FormulaUniformOnset and simply use an intercept-only 0~1 formula. 

But on the flip case, I benchmarked it, and it is significantly slower (makes sense, we have to generate a huge designmatrix first).

Difference is 127µs vs. 32ms...


Probably best to keep both for now?
