### PR TITLE
Fix onset bug

### DIFF
--- a/src/onset.jl
+++ b/src/onset.jl
@@ -65,7 +65,7 @@ function simulate_onsets(rng, onset::AbstractOnset, simulation::Simulation)
     onsets = simulate_interonset_distances(rng, onset, simulation.design)
 
     # accumulate them
-    onsets_accum = accumulate(+, onsets, dims = 1)
+    onsets_accum = accumulate(+, onsets, dims = 1, init = 1)
 
     return onsets_accum
 end

--- a/test/onset.jl
+++ b/test/onset.jl
@@ -46,7 +46,6 @@
         @test minimum(rand_vec) >= 0
     end
     @testset "sim_onsets" begin
-        
         uniform_onset = UniformOnset(; offset = 0, width = 50)
 
         accumulated_onset = UnfoldSim.simulate_onsets(

--- a/test/onset.jl
+++ b/test/onset.jl
@@ -46,7 +46,7 @@
         @test minimum(rand_vec) >= 0
     end
     @testset "sim_onsets" begin
-        # test accumulate always increasing
+        
         uniform_onset = UniformOnset(; offset = 0, width = 50)
 
         accumulated_onset = UnfoldSim.simulate_onsets(
@@ -54,7 +54,11 @@
             uniform_onset,
             gen_debug_simulation(onset = uniform_onset),
         )
+        # test accumulate always increasing
         @test all(diff(accumulated_onset, dims = 1) .>= 0)
+
+        # test that the first onset is at >=1 (not 0)
+        @test accumulated_onset[1] >= 1
     end
 
 end


### PR DESCRIPTION
At the moment, the first sampled onset may be at 0 which leads to indexing problems. Therefore, I changed the onset accumulation such that it starts at 1 which means that the first onset will be at >=1. 
I also added a test to `test/onset.jl` to test whether the first onset is >=1.