### PR TITLE
Add contributing file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contribution guide
+Contributions are very welcome. These could be typos, bug reports, feature requests, speed optimization, better code, and better documentation.
+You are very welcome to raise issues and start pull requests.
+
+## Bug reports
+If you notice any bugs, such as crashing code, incorrect results or speed issues, please raise a GitHub issue. The issue should contain a short description of the problem, (optimally) a minimal working example to reproduce the bug and which UnfoldSim.jl version you are using.
+
+## Code contributions (Pull requests)
+When opening a pull request, please add a short but meaningful description of the changes/features you implemented. Moreover, please add tests (where appropriate) to ensure that your code is working as expected.
+
+## Adding documentation
+1. We recommend to write a Literate.jl document and place it in `docs/literate/FOLDER/FILENAME.jl` with `FOLDER` being `HowTo`, `Explanation`, `Tutorial` or `Reference` ([recommended reading on the 4 categories](https://documentation.divio.com/)).
+2. Literate.jl converts the `.jl` file to a `.md` automatically and places it in `docs/src/generated/FOLDER/FILENAME.md`.
+3. Edit [make.jl](https://github.com/unfoldtoolbox/Unfold.jl/blob/main/docs/make.jl) with a reference to `docs/src/generated/FOLDER/FILENAME.md`.
+
+## Formatting (Beware of reviewdog :dog:)
+We use the [julia-format](https://github.com/julia-actions/julia-format) Github action to ensure that the code follows the formatting rules defined by [JuliaFormatter.jl](https://github.com/domluna/JuliaFormatter.jl).
+When opening a pull request [reviewdog](https://github.com/reviewdog/reviewdog) will automatically make formatting suggestions for your code.

--- a/README.md
+++ b/README.md
@@ -79,18 +79,7 @@ data, events = simulate(
 All components (design, components, onsets, noise) can be easily modified and you can simply plugin your own!
 
 ## Contributions
-
-Contributions are very welcome. These could be typos, bug reports, feature requests, speed-optimization, better code, better documentation.
-
-### How-to Contribute
-
-You are very welcome to raise issues and start pull requests!
-
-### Adding Documentation
-
-1. We recommend to write a Literate.jl document and place it in `docs/literate/FOLDER/FILENAME.jl` with `FOLDER` being `HowTo`, `Explanation`, `Tutorial` or `Reference` ([recommended reading on the 4 categories](https://documentation.divio.com/)).
-2. Literate.jl converts the `.jl` file to a `.md` automatically and places it in `docs/src/generated/FOLDER/FILENAME.md`.
-3. Edit [make.jl](https://github.com/unfoldtoolbox/Unfold.jl/blob/main/docs/make.jl) with a reference to `docs/src/generated/FOLDER/FILENAME.md`.
+Contributions of any kind are very welcome. Please have a look at [CONTRIBUTING.md](https://github.com/unfoldtoolbox/UnfoldSim.jl/blob/main/CONTRIBUTING.md) for guidance on contributing to UnfoldSim.jl.
 
 ## Contributors
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
@@ -118,8 +107,7 @@ You are very welcome to raise issues and start pull requests!
 
 
 This project follows the [all-contributors](https://allcontributors.org/docs/en/specification) specification. 
-
-Contributions of any kind welcome!
+Please reach out, if you have contributed to UnfoldSim.jl but we have not listed you as a contributor yet.
 
 ## Citation
 


### PR DESCRIPTION
- I added a `CONTRIBUTING.md` file with guidance on how to contribute. 
- I adapted the README.md:
  - I deleted the "Adding documentation" and "How-to contribute" subsections because they are now in the `CONTRIBUTING.md` file. 
  - I added a note to the "contributors" section

@behinger Do you think the content of the `CONTRIBUTING.md` file is sufficient? I was wondering whether:
-  I should a note (either in the file or the section in the readme) to encourage people to contribute even if they are not super familiar with creating PRs, issues etc. But maybe this is also too much.
- I should add more information on formatting e.g. how to avoid being swamped with suggestions by reviewdog.