### PR TITLE
event order rng removal

### DIFF
--- a/src/predefinedSimulations.jl
+++ b/src/predefinedSimulations.jl
@@ -21,7 +21,7 @@ The most used `kwargs` is: `return_epoched=true` which returns already epoched d
 
 #### Design
 - `n_repeats = 100`,
-- `event_order_function = x -> shuffle(deepcopy(rng), x)`, # random trial order
+- `event_order_function = shuffle``, # random trial order
 - `conditions = Dict(...)`,
 
 #### Component / Signal
@@ -42,7 +42,7 @@ function predef_eeg(
     rng;
     # design
     n_repeats = 100,
-    event_order_function = x -> shuffle(deepcopy(rng), x),
+    event_order_function = shuffle,
 
     # component / signal
     sfreq = 100,
@@ -91,7 +91,7 @@ function predef_eeg(
     n_subjects;
     # design
     n_items = 100,
-    event_order_function = x -> shuffle(deepcopy(rng), x),
+    event_order_function = shuffle,
     conditions = Dict(
         :condition => ["car", "face"],
         :continuous => range(-5, 5, length = 10),
@@ -147,7 +147,7 @@ The most used `kwargs` is: `return_epoched = true` which returns already epoched
 - `n_items = 100`,
 - `n_subjects = 1`,
 - `conditions = Dict(:A => ["a_small","a_big"], :B => ["b_tiny","b_large"])`,
-- `event_order_function = x -> shuffle(deepcopy(rng), x)`,
+- `event_order_function = shuffle`,
 
 #### Component / Signal
 - `signalsize = 100`, # Length of simulated hanning window
@@ -173,7 +173,7 @@ function predef_2x2(
     n_items = 100,
     n_subjects = 1,
     conditions = Dict(:A => ["a_small", "a_big"], :B => ["b_tiny", "b_large"]),
-    event_order_function = x -> shuffle(deepcopy(rng), x),
+    event_order_function = shuffle,
 
     # component / signal
     signalsize = 100,

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -80,7 +80,7 @@ function simulate(rng::AbstractRNG, simulation::Simulation; return_epoched::Bool
     responses = simulate_responses(deepcopy(rng), components, simulation)
 
     # create events data frame
-    events = UnfoldSim.generate_events(design)
+    events = UnfoldSim.generate_events(deepcopy(rng), design)
 
     if isa(onset, NoOnset)
         # reshape the responses such that the last dimension is split in two dimensions (trials per subject and subject)

--- a/test/design.jl
+++ b/test/design.jl
@@ -12,7 +12,7 @@
         ) == 1
         des = SingleSubjectDesign(;
             conditions = Dict(:A => nlevels(5), :B => nlevels(2)),
-            event_order_function = x -> sort(x, order(:B, rev = true)),
+            event_order_function = (rng, x) -> sort(x, order(:B, rev = true)),
         )
         @test generate_events(des).B[1] == "S2"
     end
@@ -35,7 +35,7 @@
             n_subjects = 10,
             n_items = 100,
             both_within = Dict(:A => nlevels(5), :B => nlevels(2)),
-            event_order_function = x -> sort(x, order(:item, rev = true)),
+            event_order_function = (rng, x) -> sort(x, order(:item, rev = true)),
         )
         @test generate_events(des).subject[1] == "S01"
 
@@ -44,7 +44,7 @@
             n_subjects = 10,
             n_items = 100,
             both_within = Dict(:A => nlevels(5), :B => nlevels(2)),
-            event_order_function = x -> sort(x, order(:B, rev = true)),
+            event_order_function = (rng, x) -> sort(x, order(:B, rev = true)),
         )
         @test generate_events(des).B[1] == "S2"
 

--- a/test/sequence.jl
+++ b/test/sequence.jl
@@ -15,7 +15,7 @@ end
 
 
     design = SingleSubjectDesign(conditions = Dict(:condition => ["one", "two"]))
-    design = SequenceDesign(design, "SCR_", StableRNG(1))
+    design = SequenceDesign(design, "SCR_")
     evt = generate_events(design)
     @test size(evt, 1) == 6
     @test evt.event == ['S', 'C', 'R', 'S', 'C', 'R']
@@ -29,16 +29,16 @@ end
     # repeat first, then sequence => same sequence
     design = SingleSubjectDesign(conditions = Dict(:condition => ["A", "B"]))
     design = RepeatDesign(design, 2)
-    design = SequenceDesign(design, "S[ABCD]", StableRNG(2))
-    evt = generate_events(design)
+    design = SequenceDesign(design, "S[ABCD]")
+    evt = generate_events(StableRNG(2), design)
 
     @test all(evt.event[2:2:end] .== 'B')
 
 
     # sequence first, then repeat => different sequence for each repetition
     design = SingleSubjectDesign(conditions = Dict(:condition => ["A", "B"]))
-    design = SequenceDesign(design, "S[ABCD]", StableRNG(2))
+    design = SequenceDesign(design, "S[ABCD]")
     design = RepeatDesign(design, 2)
-    evt = generate_events(design)
+    evt = generate_events(StableRNG(2), design)
     @test !all(evt.event[2:2:end] .== 'B')
 end


### PR DESCRIPTION
This unfortunately right now encompasses also all changes for 0.4.0, namely sequence and onsetFormulas - I'll try to get rid of that and produce a clean PR for this functionality