### PR TITLE
Fix erp simulation tutorial

### DIFF
--- a/docs/literate/HowTo/multichannel.jl
+++ b/docs/literate/HowTo/multichannel.jl
@@ -46,8 +46,13 @@ onset = UniformOnset(; width = 20, offset = 4);
 # ## Simulation
 
 # Now as usual we simulate data. Inspecting data shows our result is now indeed ~230 Electrodes large! Nice!
-data, events =
-    simulate(MersenneTwister(1), design, [mc, mc2], onset, PinkNoise(noiselevel = 0.05))
+data, events = simulate(
+    MersenneTwister(1),
+    design,
+    [mc, mc2],
+    onset,
+    PinkNoise(noiselevel = 0.05));
+    
 size(data)
 
 

--- a/docs/literate/tutorials/simulateERP.jl
+++ b/docs/literate/tutorials/simulateERP.jl
@@ -42,7 +42,7 @@ design =
     ) |> x -> RepeatDesign(x, 100);
 
 # The `generate_events` function can be used to create an events data frame from the specified experimental design.
-events_df = generate_events(design);
+events_df = generate_events(StableRNG(1), design);
 first(events_df, 5)
 # Above you can see the first five rows extracted from the events data frame representing the experimental design. Each row corresponds to one event.
 # The columns *continuous* and *condition* display the levels of the predictor variables for the specific event.

--- a/src/component.jl
+++ b/src/component.jl
@@ -111,7 +111,7 @@ function simulate_component(rng, c::MultichannelComponent, design::AbstractDesig
     y = simulate_component(rng, c.component, design)
 
     for trial = 1:size(y, 2)
-        y[:, trial] .= y[:, trial] .+ simulate_noise(rng, c.noise, size(y, 1))
+        y[:, trial] .= y[:, trial] .+ simulate_noise(deepcopy(rng), c.noise, size(y, 1))
     end
 
     y_proj = kron(y, c.projection)
@@ -144,7 +144,7 @@ julia> design = MultiSubjectDesign(;n_subjects=2,n_items=50,items_between=(;:con
 julia> simulate_component(StableRNG(1),c,design)
 """
 function simulate_component(rng, c::LinearModelComponent, design::AbstractDesign)
-    events = generate_events(design)
+    events = generate_events(deepcopy(rng), design)
 
     # special case, intercept only 
     # https://github.com/JuliaStats/StatsModels.jl/issues/269
@@ -182,7 +182,7 @@ function simulate_component(
     design::AbstractDesign;
     return_parameters = false,
 )
-    events = generate_events(design)
+    events = generate_events(deepcopy(rng), design)
 
     # add the mixed models lefthandside
     lhs_column = :tmp_dv
@@ -307,7 +307,7 @@ function simulate_responses(
     end
 
     for c in components
-        simulate_and_add!(epoch_data, c, simulation, rng)
+        simulate_and_add!(epoch_data, c, simulation, deepcopy(rng)) # TODO: `deepcopy` necessary?
     end
     return epoch_data
 end

--- a/src/helper.jl
+++ b/src/helper.jl
@@ -17,8 +17,8 @@ Obsolete - # TODO: Transfer function to Unfold.jl
 
 Function to convert output similar to unfold (data, events)
 """
-function convert(eeg, onsets, design, n_chan; reshape = true)
-    events = UnfoldSim.generate_events(design)
+function convert(rng::AbstractRNG, eeg, onsets, design, n_chan; reshape = true) # TODO: Added an rng but did not test it, either test it or (re)move function
+    events = UnfoldSim.generate_events(rng, design)
     @debug size(eeg)
     if reshape
         n_subjects = length(size(design)) == 1 ? 1 : size(design)[2]

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -66,7 +66,7 @@ function simulate(rng::AbstractRNG, simulation::Simulation; return_epoched::Bool
         size_responses = size(responses)
         signal = reshape(responses, size_responses[1:end-1]..., size(design)...)
     else # if there is an onset distribution given the next step is to create a continuous signal
-        signal, latencies = create_continuous_signal(rng, responses, simulation)
+        signal, latencies = create_continuous_signal(deepcopy(rng), responses, simulation)
         events.latency = latencies
     end
 


### PR DESCRIPTION
Fixed a few issues that were overlooked in the previous PRs #114 and #116:

- @behinger found a missing `rng` in the `generate_events` call in the `simulate_components`
- I added `deepcopy(rng)` in a few places to make sure the simulation is reproducible
- I started fixing the `generate_events` doc strings
- I added the same RNG to the `generate_events` call as in the `simulate` call in the `Simulate ERP tutorial` to make the display of the event table match the event table produced by the `simulate` function.