### PR TITLE
Revise magnitude function

### DIFF
--- a/src/headmodel.jl
+++ b/src/headmodel.jl
@@ -171,7 +171,9 @@ orientation(hart::Hartmut; type = "cortical") =
 """
     magnitude(headmodel::AbstractHeadmodel)
 
-Extract the magnitude of the orientation-including leadfield of the given `headmodel`.
+Return the magnitude for the given `headmodel` based on the leadfield (and potentially the source orientations) specified in the `headmodel`.
+
+If the `headmodel` includes source orientations these are used in the calculations, otherwise the `leadfield` is returned assuming that the source orientations are already included.
 
 By default use the orientations specified in the headmodel.
 

--- a/src/headmodel.jl
+++ b/src/headmodel.jl
@@ -175,8 +175,6 @@ Return the magnitude for the given `headmodel` based on the leadfield (and poten
 
 If the `headmodel` includes source orientations these are used in the calculations, otherwise the `leadfield` is returned assuming that the source orientations are already included.
 
-By default use the orientations specified in the headmodel.
-
 # Returns
 - `Matrix{Float64}`: Contribution of each source to the potential measured at each electrode taking into account the orientation of the sources.
     The output dimensions are `electrodes x sources`.


### PR DESCRIPTION
- I removed the `magnitude` method which computes the norm as a default. 
- I added more documentation for the `magnitude` methods.
- I added an `assert` statement in `magnitude(lf::AbstractArray{T,3}, orientation::AbstractArray{T,2}) where {T<:Real}` to ensure that the number of sources and spatial dimensions match in leadfield and orientation. 