### PR TITLE
Allow arbitrary datatype

### DIFF
--- a/src/component.jl
+++ b/src/component.jl
@@ -482,11 +482,16 @@ function simulate_responses(
     components::Vector{<:AbstractComponent},
     simulation::Simulation,
 )
+    datatype = eltype(components[1].basis)
     if n_channels(components) > 1
-        epoch_data =
-            zeros(n_channels(components), maxlength(components), length(simulation.design))
+        epoch_data = zeros(
+            datatype,
+            n_channels(components),
+            maxlength(components),
+            length(simulation.design),
+        )
     else
-        epoch_data = zeros(maxlength(components), length(simulation.design))
+        epoch_data = zeros(datatype, maxlength(components), length(simulation.design))
     end
 
     for c in components

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -257,7 +257,7 @@ function create_continuous_signal(rng, responses, simulation)
     max_length_continuoustime = Int(ceil(maximum(onsets))) .+ max_length_component
 
 
-    signal = zeros(n_chan, max_length_continuoustime, n_subjects)
+    signal = zeros(eltype(responses), n_chan, max_length_continuoustime, n_subjects)
 
     for e = 1:n_chan
         for s = 1:n_subjects


### PR DESCRIPTION
This is a minimal PR that allows UnfoldSim to output arbitrary types. We need it to be ableto define a complex-valued basis function in a component. With this fix, UnfoldSim will output complex valued simulations, which is very cooL!

for now we chose the `eltype(componentvector[1].basis)` as the output eltype

- [ ] document this feature
- [ ] add an assertion that checks that all components have the same datatype in their "basis".
