### PR TITLE
fix sizerng

### DIFF
--- a/src/component.jl
+++ b/src/component.jl
@@ -620,7 +620,7 @@ end
 Initializes an Array with zeros. Returns either a 2-dimensional for component-length  x length(design), or a 3-D for channels x component-length x length(design)
 
 """
-function init_epoch_data(components, design)
+function init_epoch_data(rng, components, design)
     max_offset = maxoffset(components)
     min_offset = minoffset(components)
     range_offset = (max_offset - min_offset)
@@ -631,14 +631,14 @@ function init_epoch_data(components, design)
             length(design),
         )
     else
-        epoch_data = zeros(maxlength(components) + range_offset, length(design))
+        epoch_data = zeros(maxlength(components) + range_offset, length(rng, design))
     end
     return epoch_data
 end
 
 function simulate_responses(rng, event_component_dict::Dict, s::Simulation)
     #@debug rng.state
-    epoch_data = init_epoch_data(event_component_dict, s.design)
+    epoch_data = init_epoch_data(deepcopy(rng), event_component_dict, s.design)
     #@debug rng.state
     evts = generate_events(deepcopy(rng), s.design)
     #@debug rng.state

--- a/src/component.jl
+++ b/src/component.jl
@@ -628,7 +628,7 @@ function init_epoch_data(rng, components, design)
         epoch_data = zeros(
             n_channels(components),
             maxlength(components) + range_offset,
-            length(design),
+            length(deepcopy(rng), design),
         )
     else
         epoch_data = zeros(maxlength(components) + range_offset, length(rng, design))

--- a/src/design.jl
+++ b/src/design.jl
@@ -573,4 +573,3 @@ function UnfoldSim.generate_events(rng, t::EffectsDesign)
     end
     return expand_grid(effects_dict)
 end
-

--- a/src/onset.jl
+++ b/src/onset.jl
@@ -125,12 +125,18 @@ function simulate_interonset_distances end
 
 function simulate_interonset_distances(rng, onset::UniformOnset, design::AbstractDesign)
     return Int.(
-        round.(rand(deepcopy(rng), onset.offset:(onset.offset+onset.width), size(design)))
+        round.(
+            rand(
+                deepcopy(rng),
+                onset.offset:(onset.offset+onset.width),
+                size(deepcopy(rng), design),
+            )
+        )
     )
 end
 
 function simulate_interonset_distances(rng, onset::LogNormalOnset, design::AbstractDesign)
-    s = size(design)
+    s = size(deepcopy(rng), design)
     fun = LogNormal(onset.μ, onset.σ)
     if !isnothing(onset.truncate_upper)
         fun = truncated(fun; upper = onset.truncate_upper)

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -241,8 +241,9 @@ function create_continuous_signal(rng, responses, simulation)
 
     (; design, components, onset, noisetype) = simulation
 
-    n_subjects = length(size(design)) == 1 ? 1 : size(design)[2]
-    n_trials = size(design)[1]
+    n_subjects =
+        length(size(deepcopy(rng), design)) == 1 ? 1 : size(deepcopy(rng), design)[2]
+    n_trials = size(deepcopy(rng), design)[1]
     n_chan = n_channels(components)
 
     # we only need to simulate onsets & pull everything together, if we 


### PR DESCRIPTION
- **FormulaOnsets**
- **initial sequence tryout**
- **fix bug in predef_eeg**
- **fix \beta missing**
- **forgot the end**
- **half way through to success for sequence designs or something**
- **everythinig except sequencelength seems to be working now**
- **added string sequence tests**
- **small doc update**
- **added jitter to the '_' trial divisor**
- **generalized LinearModelComponent to arbitrary functions instead of vectors**
- **bugfix with endless loop due to multiple dispatch**
- **function component for multi-subject**
- **forgot to define offset in LinearModelFunction**
- **Improve documentation especially quickstart, home and power analysis**
- **adapted the order of reference overviews and adapted titles**
- **Updated quickstart page**
- **minor changes**
- **fixed docstrings for predef_eeg and predef_2x2**
- **added draft of design types reference page**
- **Update quickstart.jl**
- **Add UnfoldSim logo to the documentation**
- **Finished experimental design reference page**
- **Replace logo file**
- **Update logo file**
- **Delete docs/src/assets/logo.svg**
- **Add logo as png file**
- **Added intro paragraph for Simulate ERP tutorial**
- **Improved docstrings for single- and multi-subject design**
- **Fixed simulate docstring**
- **Added cross references in docstrings**
- **Added intro sentences, matched titles and sidebar, reordered pages and added collapsible setup blocks**
- **Update noise.jl**
- **Update src/noise.jl**
- **Update src/noise.jl**
- **Update src/noise.jl**
- **add empty line for formatting reasons**
- **Update docs/literate/reference/noisetypes.jl**
- **Update docs/literate/reference/overview.jl**
- **Update docs/literate/reference/overview.jl**
- **Update docs/literate/reference/noisetypes.jl**
- **added docstring**
- **renamed to have the formula at the end**
- **merge fix, double definition of function**
- **component function test + docstring**
- **better docs**
- **added unittests**
- **fixed small wording**
- **fix tutorial with v0.3 renaming of simulate to simulate_component**
- **fix newComponent tutorial**
- **add GroundTruth desing and needed functions**
- **implement EffectsDesign; implement Tests; export Design**
- **fix size(EffectsDesign) bug**
- **fix bug in EffectsDesign test**
- **Add tutorial**
- **Apply suggestions from code review**
- **Update getGroundTruth.jl tutorial**
- **Apply suggestions from code review**
- **Update design.jl with empty line in the end**
- **fix sequence design rng**
- **fix sequence test**
- **fix rng docs**
- **finish gt tutorial**
- **Apply suggestions from code review**
- **rename offset/basis -> get_offset/get_basis; fix test ommitted begin**
- **fix: code duplications**
- **refactor: get_basis, fix basis docstring**
- **fix: format docstring; fix: remove size(design) replace with length(design); fix remaining generate_events without rng**
- **relax compat**
- **remove unused type-field**
- **added docstring warning for irregular size**
- **fix maxget_offset bug & get_basis with rng**
- **test: get_basis**
- **added docstring with rng**
- **fix: added a comment on the basisfunction-rng two inputs**
- **tests+fix: min/maxoffset, negative minoffset bug**
- **fix docustring simulation missing**
- **fix mention onsetformulas at top**
- **fix better assert msg**
- **Apply suggestions from code review**
- **Update src/component.jl**
- **fix n_channel docstring**
- **Update src/component.jl**
- **removed unnecessary interface**
- **fix component fucntion tutorial issues**
- **fix size of sequencedesign, added rng to all size/length functions**
- **fix size of sequencedesign, added rng to all size/length functions, forgot one**
