### PR TITLE
ShiftOnsetByOne

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,8 +5,6 @@ on:
       - main
     tags: '*'
   pull_request:
-    branches:
-      - main
 concurrency:
   # Skip intermediate builds: always.
   # Cancel intermediate builds: only if it is a pull request build.

--- a/src/UnfoldSim.jl
+++ b/src/UnfoldSim.jl
@@ -65,7 +65,8 @@ export simulate,
 export pad_array
 
 # export Offsets
-export UniformOnset, LogNormalOnset, NoOnset, UniformOnsetFormula, LogNormalOnsetFormula
+export UniformOnset,
+    LogNormalOnset, NoOnset, UniformOnsetFormula, LogNormalOnsetFormula, ShiftOnsetByOne
 
 # re-export StatsModels
 export DummyCoding, EffectsCoding

--- a/src/onset.jl
+++ b/src/onset.jl
@@ -21,7 +21,7 @@ UniformOnset
   offset: Int64 5
 ```
 
-See also [`LogNormalOnset`](@ref), [`NoOnset`](@ref).
+See also [`LogNormalOnset`](@ref UnfoldSim.LogNormalOnset), [`NoOnset`](@ref).
 """
 @with_kw struct UniformOnset <: AbstractOnset
     width = 50 # how many samples jitter?
@@ -51,7 +51,7 @@ LogNormalOnset
   truncate_upper: Int64 25
 ```
 
-See also [`UniformOnset`](@ref), [`NoOnset`](@ref).
+See also [`UniformOnset`](@ref UnfoldSim.UniformOnset), [`NoOnset`](@ref).
 """
 @with_kw struct LogNormalOnset <: AbstractOnset
     μ::Any  # mean
@@ -71,7 +71,7 @@ julia> onset_distribution = NoOnset()
 NoOnset()
 ```
 
-See also [`UniformOnset`](@ref), [`LogNormalOnset`](@ref).
+See also [`UniformOnset`](@ref UnfoldSim.UniformOnset), [`LogNormalOnset`](@ref UnfoldSim.LogNormalOnset).
 """
 struct NoOnset <: AbstractOnset end
 
@@ -234,10 +234,10 @@ This is helpful if your overlap/event-distribution should be dependent on some c
 # Fields
 
 - `offset_formula = @formula(0~1)`: Choose a formula depending on your `design`.
-- `offset_β = [0] `(optional): Choose a `Vector` of betas. The number of betas needs to fit the formula chosen.
-- `offset_contrasts = Dict()` (optional): Choose a contrasts-`Dict`ionary according to the StatsModels specifications.
+- `offset_β::Vector = [0] `(optional): Choose a `Vector` of betas. The number of betas needs to fit the formula chosen.
+- `offset_contrasts::Dict = Dict()` (optional): Choose a contrasts-`Dict`ionary according to the StatsModels specifications.
 - `width_formula = `@formula(0~1)`: Choose a formula depending on your `Design`.
-- `width_β = [0] (optional)`: Choose a `Vector` of betas, number needs to fit the formula chosen. 
+- `width_β::Vector = [0] (optional)`: Choose a `Vector` of betas, number needs to fit the formula chosen. 
 - `width_contrasts::Dict = Dict()` (optional) : Choose a contrasts-`Dict`ionary according to the StatsModels specifications.
 
 # Combined with [ShiftOnsetByOne](@ref)
@@ -253,7 +253,7 @@ julia> o = UnfoldSim.UniformOnsetFormula(
 )
 ```
 
-See also [`UniformOnset`](@ref) for a simplified version without linear regression specifications.
+See also [`UniformOnset`](@ref UnfoldSim.UniformOnset) for a simplified version without linear regression specifications.
 """
 @with_kw struct UniformOnsetFormula <: AbstractOnset
     width_formula = @formula(0 ~ 1)
@@ -284,21 +284,21 @@ end
 
     LogNormalOnsetFormula <: AbstractOnset
 
-provide a LogNormal Distribution of the inter-event-distances, but with regression formulas.
-This is helpful if your overlap/event-distribution should be dependent on some condition, e.g. more overlap in cond='A' than cond='B'.
+Provide a Log-normal Distribution of the inter-event distances, but with regression formulas.
+This is helpful if your overlap/event-distribution should be dependent on some condition, e.g. more overlap in cond = 'A' than cond = 'B'.
 
 # Fields
 
--`μ_formula= `@formula(0~1)`: choose a formula depending on your `design`
--`μ_β`: Choose a `Vector` of betas, number needs to fit the formula chosen. No reasonable default is available.
--`μ_contrasts` (optional): Choose a contrasts-`Dict`ionary according to the StatsModels specifications.
--`σ_formula = `@formula(0~1)`: choose a formula depending on your `Design`,
--`σ_β`: Choose a `Vector` of betas, number needs to fit the formula chosen. No reasonable default is available here 
--`σ_contrasts::Dict = Dict()` (optional) : Choose a contrasts-`Dict`ionary according to the StatsModels specifications
+- `μ_formula = @formula(0~1)` (optional): Choose a formula depending on your `design`
+- `μ_β::Vector`: Choose a `Vector` of betas, number needs to fit the formula chosen.
+- `μ_contrasts::Dict = Dict()` (optional): Choose a contrasts-`Dict`ionary according to the StatsModels specifications.
+- `σ_formula = @formula(0~1)` (optional): Choose a formula depending on your `Design`.
+- `σ_β::Vector`: Choose a `Vector` of betas, number needs to fit the formula chosen.
+- `σ_contrasts::Dict = Dict()` (optional) : Choose a contrasts-`Dict`ionary according to the StatsModels specifications.
 
-# Combined with ShiftOnsetByOne
+# Combined with [ShiftOnsetByOne](@ref)
 
-Sometimes one wants to bias not the inter-onset-distance prior to the current event, but after the current event.
+Sometimes one wants to bias not the inter-onset distance prior to the current event, but after the current event.
 This is possible by using `ShiftOnsetByOne(LogNormalOnset(...))`, effectively shifting the inter-onset-distance vector by one. See `?ShiftOnsetByOne` for a visualization.
 
 
@@ -311,9 +311,7 @@ julia> o = LogNormalOnsetFormula(
 )
 ```
 
-See also [`LogNormalOnset`](@ref) for a simplified version without linear regression specifications.
-
-    
+See also [`LogNormalOnset`](@ref UnfoldSim.LogNormalOnset) for a simplified version without linear regression specifications.    
 """
 @with_kw struct LogNormalOnsetFormula <: AbstractOnset
     μ_formula = @formula(0 ~ 1)
@@ -357,14 +355,14 @@ end
 
 This container AbstractOnset shifts the ShiftOnsetByOne.onset::AbstractOnset inter-onset-distance vector by one, adding a `0` to the front and removing the last `inter-onset distance`.
 
-This is helpful in combination with `LogNormalOnsetFormula` or `UniformOnsetFormula`, to generate biased distances not of the previous, but of the next event.
+This is helpful in combination with [`LogNormalOnsetFormula`](@ref) or [`UniformOnsetFormula`](@ref), to generate biased distances not of the previous, but of the next event.
 
 Visualized:
 
-|__1__| A |__2__| B |__3__| C
+|\\_\\_1\\_\\_| A |\\_\\_2\\_\\_| B |\\_\\_3\\_\\_| C \n
 Right now, the inter-onset distances are assigned in the order 1,2,3 inbetween the events A,B,C. After ShiftOnsetByOne we would have
 
-|__0__| A |__1__| B |__2__| C
+|\\_\\_0\\_\\_| A |\\_\\_1\\_\\_| B |\\_\\_2\\_\\_| C
 
 with 0 being a new distance of `0`, and the 3 removed (it would describe the distance after C, because there is nothing coming, the signal is not further prolonged).
 

--- a/src/onset.jl
+++ b/src/onset.jl
@@ -265,7 +265,7 @@ end
 Same functionality as `simulate_interonset_distances(rng,onsets::AbstractOnset)` except that it shifts the resulting vector by one, adding a `0` to the front and removing the last simuluated distance.
 """
 UnfoldSim.simulate_interonset_distances(rng, onsets::ShiftOnsetByOne, design) =
-    vcat(0, UnfoldSim.simulate_interonset_distances(rng, onsets.onset, design)[1:end-1])
+    vcat(0, UnfoldSim.simulate_interonset_distances(rng, onsets.onset, design)[1:(end-1)])
 
 
 """
@@ -302,7 +302,7 @@ See also [`UniformOnset`](@ref UnfoldSim.UniformOnset) for a simplified version 
 """
 @with_kw struct UniformOnsetFormula <: AbstractOnset
     width_formula = @formula(0 ~ 1)
-    width_β::Vector = [0]
+    width_β::Vector
     width_contrasts::Dict = Dict()
     offset_formula = @formula(0 ~ 1)
     offset_β::Vector = [0]
@@ -393,6 +393,3 @@ function simulate_interonset_distances(
     #@debug reduce(hcat, rand.(deepcopy(rng), funs, 1))
     return Int.(round.(offsets .+ reduce(vcat, rand.(deepcopy(rng), funs, 1))))
 end
-
-
-

--- a/src/onset.jl
+++ b/src/onset.jl
@@ -226,24 +226,23 @@ end
 """
     UniformOnsetFormula <: AbstractOnset
 
-Provides a Uniform Distribution of the inter-event-distances, but with regression formulas.
+Provides a Uniform Distribution of the inter-event distances, but with regression formulas.
 
-This is helpful if your overlap/event-distribution should be dependent on some condition, e.g. more overlap in cond='A' than cond='B'.
-**Offset** affects the minimal distance. The maximal distance is `offset + width`.
+This is helpful if your overlap/event-distribution should be dependent on some condition, e.g. more overlap in cond = 'A' than cond = 'B'.
+`Offset` affects the minimal distance. The maximal distance is `offset + width`.
 
 # Fields
 
--`offset_formula= `@formula(0~1)`: choose a formula depending on your `design`, default `@formula(0~1)``
--`offset_β=[0] (optional)`: Choose a `Vector` of betas, number needs to fit the formula chosen, default `[0]`
--`offset_contrasts` (optional): Choose a contrasts-`Dict`ionary according to the StatsModels specifications, default `Dict()`
--`width_formula = `@formula(0~1)`: choose a formula depending on your `Design`,
--`width_β=[0] (optional)`: Choose a `Vector` of betas, number needs to fit the formula chosen. 
--`width_contrasts::Dict = Dict()` (optional) : Choose a contrasts-`Dict`ionary according to the StatsModels specifications
+- `offset_formula = @formula(0~1)`: Choose a formula depending on your `design`.
+- `offset_β = [0] `(optional): Choose a `Vector` of betas. The number of betas needs to fit the formula chosen.
+- `offset_contrasts = Dict()` (optional): Choose a contrasts-`Dict`ionary according to the StatsModels specifications.
+- `width_formula = `@formula(0~1)`: Choose a formula depending on your `Design`.
+- `width_β = [0] (optional)`: Choose a `Vector` of betas, number needs to fit the formula chosen. 
+- `width_contrasts::Dict = Dict()` (optional) : Choose a contrasts-`Dict`ionary according to the StatsModels specifications.
 
-# Combined with ShiftOnsetByOne
-Sometimes one wants to bias not the inter-onset-distance prior to the current event, but after the current event.
+# Combined with [ShiftOnsetByOne](@ref)
+Sometimes one wants to bias not the inter-onset distance prior to the current event, but after the current event.
 This is possible by using `ShiftOnsetByOne(UniformOnset(...))`, effectively shifting the inter-onset-distance vector by one. See `?ShiftOnsetByOne` for a visualization.
-
 
 
 # Examples
@@ -252,10 +251,9 @@ julia> o = UnfoldSim.UniformOnsetFormula(
     width_formula = @formula(0 ~ 1 + cond),
     width_β = [50, 20],
 )
-
 ```
 
-See also [`UniformOnset`](@ref) for a simplified version without linear regression specifications
+See also [`UniformOnset`](@ref) for a simplified version without linear regression specifications.
 """
 @with_kw struct UniformOnsetFormula <: AbstractOnset
     width_formula = @formula(0 ~ 1)
@@ -306,15 +304,14 @@ This is possible by using `ShiftOnsetByOne(LogNormalOnset(...))`, effectively sh
 
 # Examples
 ```julia-repl
-julia> o = UnfoldSim.LogNormalOnsetFormula(
+julia> o = LogNormalOnsetFormula(
     σ_formula = @formula(0 ~ 1 + cond),
     σ_β = [0.25, 0.5],
     μ_β = [2],
 )
-
 ```
 
-See also [`LogNormalOnset`](@ref) for a simplified version without linear regression specifications
+See also [`LogNormalOnset`](@ref) for a simplified version without linear regression specifications.
 
     
 """
@@ -357,22 +354,24 @@ end
 
 """
     ShiftOnsetByOne <:AbstractOnset
-This container AbstractOnset shifts the ShiftOnsetByOne.onset::AbstractOnset inter-onset-distance vector by one, adding a `0` to the front and removing the last `inter-onset-distance`.
 
-This is helpful in combination with `LogNormalOnsetFormula` or `UniformOnsetFormula`, to generate biased distances not of the previous, but of the next Event.
+This container AbstractOnset shifts the ShiftOnsetByOne.onset::AbstractOnset inter-onset-distance vector by one, adding a `0` to the front and removing the last `inter-onset distance`.
+
+This is helpful in combination with `LogNormalOnsetFormula` or `UniformOnsetFormula`, to generate biased distances not of the previous, but of the next event.
 
 Visualized:
 
 |__1__| A |__2__| B |__3__| C
-Right now, the interonset-distances are assigned in the order 1,2,3 inbetween the events A,B,C. After ShiftOnsetByOne we would have
+Right now, the inter-onset distances are assigned in the order 1,2,3 inbetween the events A,B,C. After ShiftOnsetByOne we would have
 
 |__0__| A |__1__| B |__2__| C
 
-with 0 being a new distance of `0`, and the 3 removed (it would describe the distance after C, because there is nothing coming, the signal is not further prolonged)
+with 0 being a new distance of `0`, and the 3 removed (it would describe the distance after C, because there is nothing coming, the signal is not further prolonged).
 
 """
 struct ShiftOnsetByOne <: AbstractOnset
     onset::AbstractOnset
 end
+
 UnfoldSim.simulate_interonset_distances(rng, onsets::ShiftOnsetByOne, design) =
     vcat(0, UnfoldSim.simulate_interonset_distances(rng, onsets.onset, design)[1:end-1])

--- a/src/onset.jl
+++ b/src/onset.jl
@@ -225,26 +225,41 @@ end
 
 """
     UniformOnsetFormula <: AbstractOnset
-provide a Uniform Distribution of the inter-event-distances, but with regression formulas.
-This is helpful if your overlap/event-distribution should be dependend on some condition, e.g. more overlap in cond='A' than cond='B'.
 
-**width**
+Provides a Uniform Distribution of the inter-event-distances, but with regression formulas.
 
-        -`width_formula`: choose a formula depending on your `Design`, default `@formula(0~1)`
-        -`width_β`: Choose a `Vector` of betas, number needs to fit the formula chosen, no default.
-        -`width_contrasts` (optional): Choose a contrasts-`Dict`ionary according to the StatsModels specifications, default `Dict()``
-    
-**offset** is the minimal distance. The maximal distance is `offset + width`.
+This is helpful if your overlap/event-distribution should be dependent on some condition, e.g. more overlap in cond='A' than cond='B'.
+**Offset** affects the minimal distance. The maximal distance is `offset + width`.
 
-        -`offset_formula`: choose a formula depending on your `design`, default `@formula(0~1)``
-        -`offset_β`: Choose a `Vector` of betas, number needs to fit the formula chosen, default `[0]`
-        -`offset_contrasts` (optional): Choose a contrasts-`Dict`ionary according to the StatsModels specifications, default `Dict()`
+# Fields
 
-See `UniformOnset` for a simplified version without linear regression specifications
+-`offset_formula= `@formula(0~1)`: choose a formula depending on your `design`, default `@formula(0~1)``
+-`offset_β=[0] (optional)`: Choose a `Vector` of betas, number needs to fit the formula chosen, default `[0]`
+-`offset_contrasts` (optional): Choose a contrasts-`Dict`ionary according to the StatsModels specifications, default `Dict()`
+-`width_formula = `@formula(0~1)`: choose a formula depending on your `Design`,
+-`width_β=[0] (optional)`: Choose a `Vector` of betas, number needs to fit the formula chosen. 
+-`width_contrasts::Dict = Dict()` (optional) : Choose a contrasts-`Dict`ionary according to the StatsModels specifications
+
+# Combined with ShiftOnsetByOne
+Sometimes one wants to bias not the inter-onset-distance prior to the current event, but after the current event.
+This is possible by using `ShiftOnsetByOne(UniformOnset(...))`, effectively shifting the inter-onset-distance vector by one. See `?ShiftOnsetByOne` for a visualization.
+
+
+
+# Examples
+```julia-repl
+julia> o = UnfoldSim.UniformOnsetFormula(
+    width_formula = @formula(0 ~ 1 + cond),
+    width_β = [50, 20],
+)
+
+```
+
+See also [`UniformOnset`](@ref) for a simplified version without linear regression specifications
 """
 @with_kw struct UniformOnsetFormula <: AbstractOnset
     width_formula = @formula(0 ~ 1)
-    width_β::Vector
+    width_β::Vector = [0]
     width_contrasts::Dict = Dict()
     offset_formula = @formula(0 ~ 1)
     offset_β::Vector = [0]
@@ -268,29 +283,40 @@ end
 
 
 """
+
     LogNormalOnsetFormula <: AbstractOnset
+
 provide a LogNormal Distribution of the inter-event-distances, but with regression formulas.
-This is helpful if your overlap/event-distribution should be dependend on some condition, e.g. more overlap in cond='A' than cond='B'.
+This is helpful if your overlap/event-distribution should be dependent on some condition, e.g. more overlap in cond='A' than cond='B'.
 
-**μ**
+# Fields
 
-        -`μ_formula`: choose a formula depending on your `Design`, default `@formula(0~1)`
-        -`μ_β`: Choose a `Vector` of betas, number needs to fit the formula chosen, default `[0]`
-        -`μ_contrasts` (optional): Choose a contrasts-`Dict`ionary according to the StatsModels specifications, default `Dict()``
-   
-        -`σ_formula`: choose a formula depending on your `Design`, default `@formula(0~1)`
-        -`σ_β`: Choose a `Vector` of betas, number needs to fit the formula chosen, default `[0]`
-        -`σ_contrasts` (optional): Choose a contrasts-`Dict`ionary according to the StatsModels specifications, default `Dict()``
+-`μ_formula= `@formula(0~1)`: choose a formula depending on your `design`
+-`μ_β`: Choose a `Vector` of betas, number needs to fit the formula chosen. No reasonable default is available.
+-`μ_contrasts` (optional): Choose a contrasts-`Dict`ionary according to the StatsModels specifications.
+-`σ_formula = `@formula(0~1)`: choose a formula depending on your `Design`,
+-`σ_β`: Choose a `Vector` of betas, number needs to fit the formula chosen. No reasonable default is available here 
+-`σ_contrasts::Dict = Dict()` (optional) : Choose a contrasts-`Dict`ionary according to the StatsModels specifications
+
+# Combined with ShiftOnsetByOne
+
+Sometimes one wants to bias not the inter-onset-distance prior to the current event, but after the current event.
+This is possible by using `ShiftOnsetByOne(LogNormalOnset(...))`, effectively shifting the inter-onset-distance vector by one. See `?ShiftOnsetByOne` for a visualization.
+
+
+# Examples
+```julia-repl
+julia> o = UnfoldSim.LogNormalOnsetFormula(
+    σ_formula = @formula(0 ~ 1 + cond),
+    σ_β = [0.25, 0.5],
+    μ_β = [2],
+)
+
+```
+
+See also [`LogNormalOnset`](@ref) for a simplified version without linear regression specifications
+
     
-**offset** is the minimal distance. The maximal distance is `offset + width`.
-
-        -`offset_formula`: choose a formula depending on your `design`, default `@formula(0~1)``
-        -`offset_β`: Choose a `Vector` of betas, number needs to fit the formula chosen, default `[0]`
-        -`offset_contrasts` (optional): Choose a contrasts-`Dict`ionary according to the StatsModels specifications, default `Dict()`
-
-`truncate_upper` - truncate at some sample, default nothing
-
-See `LogNormalOnset` for a simplified version without linear regression specifications
 """
 @with_kw struct LogNormalOnsetFormula <: AbstractOnset
     μ_formula = @formula(0 ~ 1)
@@ -329,3 +355,24 @@ function simulate_interonset_distances(
 end
 
 
+"""
+    ShiftOnsetByOne <:AbstractOnset
+This container AbstractOnset shifts the ShiftOnsetByOne.onset::AbstractOnset inter-onset-distance vector by one, adding a `0` to the front and removing the last `inter-onset-distance`.
+
+This is helpful in combination with `LogNormalOnsetFormula` or `UniformOnsetFormula`, to generate biased distances not of the previous, but of the next Event.
+
+Visualized:
+
+|__1__| A |__2__| B |__3__| C
+Right now, the interonset-distances are assigned in the order 1,2,3 inbetween the events A,B,C. After ShiftOnsetByOne we would have
+
+|__0__| A |__1__| B |__2__| C
+
+with 0 being a new distance of `0`, and the 3 removed (it would describe the distance after C, because there is nothing coming, the signal is not further prolonged)
+
+"""
+struct ShiftOnsetByOne <: AbstractOnset
+    onset::AbstractOnset
+end
+UnfoldSim.simulate_interonset_distances(rng, onsets::ShiftOnsetByOne, design) =
+    vcat(0, UnfoldSim.simulate_interonset_distances(rng, onsets.onset, design)[1:end-1])

--- a/test/onset.jl
+++ b/test/onset.jl
@@ -103,4 +103,21 @@
 
 
     end
+
+    @testset "ShiftOnset" begin
+        o = UniformOnset(width = 50, offset = 10)
+        events = generate_events(design)
+        without = UnfoldSim.simulate_interonset_distances(StableRNG(1), o, design)
+        with = UnfoldSim.simulate_interonset_distances(
+            StableRNG(1),
+            ShiftOnsetByOne(o),
+            design,
+        )
+        # ShiftOnsetByOne adds the first onset to the interonset-distances, thereby not startin
+        @test with[1] == 0
+
+        @test without[1:end-1] == with[2:end]
+
+
+    end
 end

--- a/test/onset.jl
+++ b/test/onset.jl
@@ -120,7 +120,7 @@
         # ShiftOnsetByOne adds a 0 to the front, thereby the first "non-0" "real" simulated inter onset distance is used for the second event
         @test with[1] == 0
 
-        @test without[1:end-1] == with[2:end]
+        @test without[1:(end-1)] == with[2:end]
 
 
     end

--- a/test/onset.jl
+++ b/test/onset.jl
@@ -105,8 +105,12 @@
     end
 
     @testset "ShiftOnset" begin
+        design =
+            SingleSubjectDesign(conditions = Dict(:cond => ["A", "B"])) |>
+            x -> RepeatDesign(x, 100)
+
         o = UniformOnset(width = 50, offset = 10)
-        events = generate_events(design)
+
         without = UnfoldSim.simulate_interonset_distances(StableRNG(1), o, design)
         with = UnfoldSim.simulate_interonset_distances(
             StableRNG(1),


### PR DESCRIPTION
- **FormulaOnsets**
- **initial sequence tryout**
- **fix bug in predef_eeg**
- **fix \beta missing**
- **forgot the end**
- **half way through to success for sequence designs or something**
- **everythinig except sequencelength seems to be working now**
- **added string sequence tests**
- **small doc update**
- **added jitter to the '_' trial divisor**
- **generalized LinearModelComponent to arbitrary functions instead of vectors**
- **bugfix with endless loop due to multiple dispatch**
- **function component for multi-subject**
- **forgot to define offset in LinearModelFunction**
- **Improve documentation especially quickstart, home and power analysis**
- **adapted the order of reference overviews and adapted titles**
- **Updated quickstart page**
- **minor changes**
- **fixed docstrings for predef_eeg and predef_2x2**
- **added draft of design types reference page**
- **Update quickstart.jl**
- **Add UnfoldSim logo to the documentation**
- **Finished experimental design reference page**
- **Replace logo file**
- **Update logo file**
- **Delete docs/src/assets/logo.svg**
- **Add logo as png file**
- **Added intro paragraph for Simulate ERP tutorial**
- **Improved docstrings for single- and multi-subject design**
- **Fixed simulate docstring**
- **Added cross references in docstrings**
- **Added intro sentences, matched titles and sidebar, reordered pages and added collapsible setup blocks**
- **Update noise.jl**
- **Update src/noise.jl**
- **Update src/noise.jl**
- **Update src/noise.jl**
- **add empty line for formatting reasons**
- **Update docs/literate/reference/noisetypes.jl**
- **Update docs/literate/reference/overview.jl**
- **Update docs/literate/reference/overview.jl**
- **Update docs/literate/reference/noisetypes.jl**
- **added docstring**
- **renamed to have the formula at the end**
- **merge fix, double definition of function**
- **component function test + docstring**
- **better docs**
- **added unittests**
- **fixed small wording**
- **fix tutorial with v0.3 renaming of simulate to simulate_component**
- **fix newComponent tutorial**
- **add GroundTruth desing and needed functions**
- **implement EffectsDesign; implement Tests; export Design**
- **fix size(EffectsDesign) bug**
- **fix bug in EffectsDesign test**
- **Add tutorial**
- **Apply suggestions from code review**
- **Update getGroundTruth.jl tutorial**
- **Apply suggestions from code review**
- **Update design.jl with empty line in the end**
- **fix sequence design rng**
- **fix sequence test**
- **fix rng docs**
- **finish gt tutorial**
- **Apply suggestions from code review**
- **rename offset/basis -> get_offset/get_basis; fix test ommitted begin**
- **fix: code duplications**
- **refactor: get_basis, fix basis docstring**
- **fix: format docstring; fix: remove size(design) replace with length(design); fix remaining generate_events without rng**
- **relax compat**
- **remove unused type-field**
- **added docstring warning for irregular size**
- **fix maxget_offset bug & get_basis with rng**
- **test: get_basis**
- **added docstring with rng**
- **fix: added a comment on the basisfunction-rng two inputs**
- **tests+fix: min/maxoffset, negative minoffset bug**
- **fix docustring simulation missing**
- **fix mention onsetformulas at top**
- **fix better assert msg**
- **Apply suggestions from code review**
- **Update src/component.jl**
- **fix n_channel docstring**
- **Update src/component.jl**
- **removed unnecessary interface**
- **fix component fucntion tutorial issues**
- **improved sequence-tutorial**
- **better docfix**
